### PR TITLE
Add functionality for creating an account by converting the account details from a JPA to a Entity 

### DIFF
--- a/src/main/java/com/wolfecodes/bankingapp/mapper/AccountMapper.java
+++ b/src/main/java/com/wolfecodes/bankingapp/mapper/AccountMapper.java
@@ -1,0 +1,23 @@
+package com.wolfecodes.bankingapp.mapper;
+
+import com.wolfecodes.bankingapp.dto.AccountDto;
+import com.wolfecodes.bankingapp.entity.Account;
+
+public class AccountMapper {
+    public static Account mapToAccount(AccountDto accountDto) {
+        Account account = new Account(
+                accountDto.getId(),
+                accountDto.getAccountHolderName(),
+                accountDto.getBalance()
+        );
+        return account;
+    }
+    public static AccountDto mapToAccountDto(Account account) {
+        AccountDto accountDto = new AccountDto(
+                account.getId(),
+                account.getAccountHolderName(),
+                account.getBalance()
+        );
+        return accountDto;
+    }
+}

--- a/src/main/java/com/wolfecodes/bankingapp/service/AccountService.java
+++ b/src/main/java/com/wolfecodes/bankingapp/service/AccountService.java
@@ -1,0 +1,8 @@
+package com.wolfecodes.bankingapp.service;
+
+import com.wolfecodes.bankingapp.dto.AccountDto;
+
+
+public interface AccountService {
+    AccountDto createAccount(AccountDto accountDto);
+}

--- a/src/main/java/com/wolfecodes/bankingapp/service/impl/AccountServiceimpl.java
+++ b/src/main/java/com/wolfecodes/bankingapp/service/impl/AccountServiceimpl.java
@@ -1,0 +1,26 @@
+package com.wolfecodes.bankingapp.service.impl;
+
+import com.wolfecodes.bankingapp.dto.AccountDto;
+import com.wolfecodes.bankingapp.entity.Account;
+import com.wolfecodes.bankingapp.mapper.AccountMapper;
+import com.wolfecodes.bankingapp.repository.AccountRepository;
+import com.wolfecodes.bankingapp.service.AccountService;
+import org.springframework.stereotype.Service;
+
+@Service
+
+public class AccountServiceimpl implements AccountService {
+    private AccountRepository accountRepository;
+
+
+    public AccountServiceimpl(AccountRepository accountRepository) {
+        this.accountRepository = accountRepository;
+    }
+
+    @Override
+    public AccountDto createAccount(AccountDto accountDto) {
+        Account account = AccountMapper.mapToAccount(accountDto);
+        Account savedAccount = accountRepository.save(account);
+        return AccountMapper.mapToAccountDto(savedAccount);
+    }
+}


### PR DESCRIPTION
In this PR we created a method ```createAccount``` which takes in the dto (data transfer object) and returns a server-side entity. We implemented two mapper classes that map over ```accountDto```  and return an account entity and another that does the same logic but in reverse and returns the same data in a non-entity format. 